### PR TITLE
Combat statuses

### DIFF
--- a/Assets/Scripts/CombatActions/CombatActions.cs
+++ b/Assets/Scripts/CombatActions/CombatActions.cs
@@ -143,7 +143,8 @@ public class DefendAction : aCombatAction
 {
     protected override void DoSelf(CombatTarget targetInformation)
     {
-        Debug.Log("I have defended");
+        // The defend action gives the defend condition
+        targetInformation.targetUnit.AddCondition(ConditionType.Defend);
     }
     protected override void DoMultiTarget(CombatTarget targetInformation)
     {
@@ -172,7 +173,6 @@ public class PowerAction : aCombatAction
     }
     protected override void DoMultiTarget(CombatTarget targetInformation)
     {
-        Debug.Log("Doing multitarget power");
         CombatantType sideBeingTargeted = targetInformation.sideBeingTargeted;
         List<aCombatant> whoThough;
         if (sideBeingTargeted == CombatantType.ALLIES)

--- a/Assets/Scripts/Combatants/Combatant.cs
+++ b/Assets/Scripts/Combatants/Combatant.cs
@@ -215,6 +215,7 @@ namespace Combatant
 
         public void ApplyConditions()
         {
+            // For every condition, apply its effect to the player
             for (int i = 0; i < _conditions.Count; i++)
             {
                 ConditionManager.ApplyConditionEffect(this, _conditions[i]);
@@ -223,6 +224,7 @@ namespace Combatant
 
         public void UpdateActiveConditions()
         {
+            // Evaluate which conditions have expired and should no longer affect a combatant
             List<int> expiredConditions = new List<int>();
             for (int i = 0; i < _conditions.Count; i++)
             {
@@ -234,6 +236,7 @@ namespace Combatant
             }
             foreach(int i in expiredConditions)
             {
+                // Conditions might modify a character's stats. We need to reset those stats when the condition is done
                 ConditionManager.CleanUpCondition(this, _conditions[i]);
                 _conditions.RemoveAt(i);
             }

--- a/Assets/Scripts/Combatants/Combatant.cs
+++ b/Assets/Scripts/Combatants/Combatant.cs
@@ -66,10 +66,10 @@ namespace Combatant
         //Store the body part lists in the inventory 
         [SerializeField]
         public List<BodyPart> _bodyPartsInventory = new List<BodyPart>();
+        protected List<ConditionData> _conditions = new List<ConditionData>();
 
         //Store the powers in a list - need to figure out how to populate this
         public List<Power> _powers = new List<Power>();
-
         protected CombatantType _side;
 
         public List<Power> FilterPowerByTargetType(CombatActionTargets targetType)
@@ -204,8 +204,40 @@ namespace Combatant
         {
             _hpSlider = s;
         }
-
         public abstract void UpdateStatus();
+
+        // Conditions stuff
+        public void AddCondition(ConditionType condition)
+        {
+
+            _conditions.Add(ConditionManager.CreateConditionData(condition));
+        }
+
+        public void ApplyConditions()
+        {
+            for (int i = 0; i < _conditions.Count; i++)
+            {
+                ConditionManager.ApplyConditionEffect(this, _conditions[i]);
+            }
+        }
+
+        public void UpdateActiveConditions()
+        {
+            List<int> expiredConditions = new List<int>();
+            for (int i = 0; i < _conditions.Count; i++)
+            {
+                _conditions[i].currentDuration++;
+                if (_conditions[i].currentDuration == _conditions[i].maxDuration)
+                {
+                    expiredConditions.Add(i);
+                }
+            }
+            foreach(int i in expiredConditions)
+            {
+                ConditionManager.CleanUpCondition(this, _conditions[i]);
+                _conditions.RemoveAt(i);
+            }
+        }
     }
 
     public class Protagonist : aCombatant

--- a/Assets/Scripts/Combatants/Conditions.meta
+++ b/Assets/Scripts/Combatants/Conditions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef213a14e6a85c64da5cbf7e5fc79955
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Combatants/Conditions/Conditions.cs
+++ b/Assets/Scripts/Combatants/Conditions/Conditions.cs
@@ -15,6 +15,8 @@ public class ConditionData
     public aCondition conditionBehavior;
 }
 
+// A static class that handles everything related to conditions.
+// This keeps code execution encapsulated within this domain
 public static class ConditionManager
 {
     public static void ApplyConditionEffect(aCombatant who, ConditionData data)
@@ -46,12 +48,16 @@ public static class ConditionManager
     }
 }
 
+// The abstract representation of a condition
 public abstract class aCondition
 {
     public abstract void ApplyConditionEffect(aCombatant who);
     public abstract void CleanUp(aCombatant who);
 }
 
+// Example condition - Defend.
+// Adds a bonus to armor while active
+// Removes that bonus on clean up
 public class DefendCondition : aCondition
 {
     public override void ApplyConditionEffect(aCombatant who)

--- a/Assets/Scripts/Combatants/Conditions/Conditions.cs
+++ b/Assets/Scripts/Combatants/Conditions/Conditions.cs
@@ -1,0 +1,66 @@
+using Combatant;
+
+public enum ConditionType
+{
+    Normal,
+    Defend
+}
+
+[System.Serializable]
+public class ConditionData
+{
+    public int maxDuration;
+    public int currentDuration;
+    public ConditionType type;
+    public aCondition conditionBehavior;
+}
+
+public static class ConditionManager
+{
+    public static void ApplyConditionEffect(aCombatant who, ConditionData data)
+    {
+        if (data.conditionBehavior == null) return;
+        data.conditionBehavior.ApplyConditionEffect(who);
+    }
+
+    public static void CleanUpCondition(aCombatant who, ConditionData data)
+    {
+        if (data.conditionBehavior == null) return;
+        data.conditionBehavior.CleanUp(who);
+    }
+
+    public static ConditionData CreateConditionData(ConditionType type)
+    {
+        ConditionData data = new();
+        data.type = type;
+        switch (type)
+        {
+            case ConditionType.Defend:
+                data.maxDuration = 1;
+                data.currentDuration = 0;
+                data.conditionBehavior = new DefendCondition();
+                return data;
+            default:
+                return data;
+        }
+    }
+}
+
+public abstract class aCondition
+{
+    public abstract void ApplyConditionEffect(aCombatant who);
+    public abstract void CleanUp(aCombatant who);
+}
+
+public class DefendCondition : aCondition
+{
+    public override void ApplyConditionEffect(aCombatant who)
+    {
+        who.AffectStatByType(StatType.Shield, 10);
+    }
+
+    public override void CleanUp(aCombatant who)
+    {
+        who.AffectStatByType(StatType.Shield, -10);
+    }
+}

--- a/Assets/Scripts/Combatants/Conditions/Conditions.cs.meta
+++ b/Assets/Scripts/Combatants/Conditions/Conditions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddcc1bd0bc4396a49a6a9d84d546ed9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Turn-System/CombatManager.cs
+++ b/Assets/Scripts/Turn-System/CombatManager.cs
@@ -56,7 +56,7 @@ public class CombatManager : MonoBehaviour
         {
             SwitchSides();
         }
-        stateMachine.Next(TurnStateType.TURN_START);
+        stateMachine.Next(TurnStateType.UPDATE_CONDITIONS);
     }
 
     public void ExecuteCombatAction()
@@ -79,6 +79,10 @@ public class CombatManager : MonoBehaviour
         targetInformation = targetInfo;
         currentAction = action;
         action.SetActingAgent(CombatantData.GetGroup(_activeType)[playerIndex]);
+        if (action.GetActionTarget() == CombatActionTargets.Self)
+        {
+            targetInformation.targetUnit = _activeCombatants[_currentTurn];
+        }
         uiManager.ShowByTarget(targetInformation.typeOfTarget);
         stateMachine.Transition();
     }


### PR DESCRIPTION
<!---
Pull request template created by Rob Reddick. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Adding the backend system for applying status effects and conditions to combatants.
This fixes the fact that defend was doing nothing at all.

## Please describe how to test
Open the Level-1 scene. 
Hit play. 
Choose attack with all characters. 
Keep track of how much damage your characters are receiving. 
Stop the game.
Hit play again and pick defend with all characters, 
You should notice a decrease in damage taken.

## Relevant Screenshots
Updated turn state machine
![PXL_20240420_165903360](https://github.com/heenathadani/603_DataManagement/assets/9394777/6f9a5667-c8fb-4611-99c9-d43b7e7e7b27)


## What task does this PR address?
#62 

## What week is this due in?
Playtest 2