### PR TITLE
Dialogue exploration updates

### DIFF
--- a/Assets/Prefabs/NPC/Terminal_NPC.prefab
+++ b/Assets/Prefabs/NPC/Terminal_NPC.prefab
@@ -1,0 +1,241 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1548014860379432032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2683264636281546866}
+  - component: {fileID: 1134820109366605857}
+  - component: {fileID: 5252898485248812548}
+  - component: {fileID: 6338417348777975503}
+  m_Layer: 0
+  m_Name: Terminal_NPC
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2683264636281546866
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548014860379432032}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.83, y: 2.54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7558359066833785716}
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1134820109366605857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548014860379432032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3111e853a5cd3ca4f90f19c770463ad0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  characterName: TRM-null.01
+  dialogueList:
+  - To perform our tasks, our creators bestowed upon us shape. As we did our duty,
+    our parts fell victim to time, decay and corruption. To continue to do as bid,
+    we replaced these defects in ourselves.
+  optionList:
+  - <0-VD> ...Hello?
+  - <HR.4c3> ...
+  - <V1R.91-L> Are you alright?
+  dialogueAfterOptionList:
+  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
+  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
+  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
+  enemyFormation: {fileID: 11400000, guid: afe6702d58773bf4aa806dde254cd77d, type: 2}
+  combatOptionId: -1
+  combatOptionId2: -1
+--- !u!212 &5252898485248812548
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548014860379432032}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 1878799085, guid: 2ca1506dac0be7d488bb0ab1a5aa7449, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &6338417348777975503
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548014860379432032}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.18582469, y: -0.08129835}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.17, y: 0.25}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.6316494, y: 1.8165274}
+  m_EdgeRadius: 0
+--- !u!1001 &3453535096643404846
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2683264636281546866}
+    m_Modifications:
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8687114460629269470, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_Name
+      value: Terminal_Sprite
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d22d04ec8703f43a629e3c2a272f73, type: 3}
+--- !u!4 &7558359066833785716 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+    type: 3}
+  m_PrefabInstance: {fileID: 3453535096643404846}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/NPC/Terminal_NPC.prefab.meta
+++ b/Assets/Prefabs/NPC/Terminal_NPC.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 914712147994fb34b98bd9bec546b0fe
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/DialogueUI.prefab
+++ b/Assets/Prefabs/UI/DialogueUI.prefab
@@ -36,9 +36,10 @@ RectTransform:
   - {fileID: 8599549280108962840}
   - {fileID: 3182613841118150977}
   - {fileID: 6495708093045399251}
+  - {fileID: 317826900958546672}
   - {fileID: 2830147188494224125}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -108,6 +109,140 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!1 &1469869247374146294
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 317826900958546672}
+  - component: {fileID: 5747320564057198750}
+  - component: {fileID: 8927890995773496585}
+  - component: {fileID: 6902318768248857758}
+  m_Layer: 5
+  m_Name: Option3Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &317826900958546672
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469869247374146294}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4260725887631833264}
+  m_Father: {fileID: 8483409896308202653}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -556}
+  m_SizeDelta: {x: 1824.1, y: 60.8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5747320564057198750
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469869247374146294}
+  m_CullTransparentMesh: 1
+--- !u!114 &8927890995773496585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469869247374146294}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6902318768248857758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1469869247374146294}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8927890995773496585}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: GoToEndDialogue
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1965706339939863033
 GameObject:
   m_ObjectHideFlags: 0
@@ -780,6 +915,141 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &5313257085738836864
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4260725887631833264}
+  - component: {fileID: 8346407659439312402}
+  - component: {fileID: 4176298312651755526}
+  m_Layer: 5
+  m_Name: Option2Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4260725887631833264
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5313257085738836864}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 317826900958546672}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8346407659439312402
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5313257085738836864}
+  m_CullTransparentMesh: 1
+--- !u!114 &4176298312651755526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5313257085738836864}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: option 2:hdfjahsdfjkhasdjkfhasdjkfhaskjldf
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5784268938770681234
 GameObject:
   m_ObjectHideFlags: 0
@@ -950,8 +1220,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -359.1}
-  m_SizeDelta: {x: 1889, y: 342}
+  m_AnchoredPosition: {x: 0, y: -394.79324}
+  m_SizeDelta: {x: 1889, y: 413.3865}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2112658068096738172
 CanvasRenderer:

--- a/Assets/Scenes/ExplorationScene.unity
+++ b/Assets/Scenes/ExplorationScene.unity
@@ -263,6 +263,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &837662195 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+    type: 3}
+  m_PrefabInstance: {fileID: 1223474481}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &873347856
 GameObject:
   m_ObjectHideFlags: 0
@@ -41864,6 +41870,79 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1223474481
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1759472406}
+    m_Modifications:
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8687114460629269470, guid: 78d22d04ec8703f43a629e3c2a272f73,
+        type: 3}
+      propertyPath: m_Name
+      value: Terminal_Sprite
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 78d22d04ec8703f43a629e3c2a272f73, type: 3}
 --- !u!114 &1223850581 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7811292923029834981, guid: b9582278e87858c49b45724c0240626f,
@@ -42009,6 +42088,11 @@ PrefabInstance:
       objectReference: {fileID: 1424233431}
     - target: {fileID: 7811292923029834981, guid: b9582278e87858c49b45724c0240626f,
         type: 3}
+      propertyPath: option3Button
+      value: 
+      objectReference: {fileID: 1923013108}
+    - target: {fileID: 7811292923029834981, guid: b9582278e87858c49b45724c0240626f,
+        type: 3}
       propertyPath: continueButton
       value: 
       objectReference: {fileID: 1028120861}
@@ -42022,6 +42106,11 @@ PrefabInstance:
       propertyPath: option2Content
       value: 
       objectReference: {fileID: 1147316414}
+    - target: {fileID: 7811292923029834981, guid: b9582278e87858c49b45724c0240626f,
+        type: 3}
+      propertyPath: option3Content
+      value: 
+      objectReference: {fileID: 1923013109}
     - target: {fileID: 7811292923029834981, guid: b9582278e87858c49b45724c0240626f,
         type: 3}
       propertyPath: dialogueContent
@@ -42042,6 +42131,67 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b9582278e87858c49b45724c0240626f, type: 3}
+--- !u!1 &1759472404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1759472406}
+  - component: {fileID: 1759472405}
+  m_Layer: 0
+  m_Name: Terminal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1759472405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1759472404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3111e853a5cd3ca4f90f19c770463ad0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  characterName: TRM-null.01
+  dialogueList:
+  - To perform our tasks, our creators bestowed upon us shape. As we did our duty,
+    our parts fell victim to time, decay and corruption. To continue to do as bid,
+    we replaced these defects in ourselves.
+  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
+  optionList:
+  - 
+  - ...
+  - ...Hello?
+  dialogueAfterOptionList:
+  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
+  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
+  enemyFormation: {fileID: 11400000, guid: afe6702d58773bf4aa806dde254cd77d, type: 2}
+  combatOptionId: 2
+  combatOptionId2: 0
+--- !u!4 &1759472406
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1759472404}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.78, y: 33.49, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 837662195}
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1869916732
 GameObject:
   m_ObjectHideFlags: 0
@@ -42281,6 +42431,11 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.42452833
       objectReference: {fileID: 0}
+    - target: {fileID: 2830147188494224125, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -494
+      objectReference: {fileID: 0}
     - target: {fileID: 4381533773057188742, guid: 17c60ae26a5d4194b87cbe75cd194957,
         type: 3}
       propertyPath: m_Color.a
@@ -42355,7 +42510,12 @@ PrefabInstance:
     - target: {fileID: 5818157851114449726, guid: 17c60ae26a5d4194b87cbe75cd194957,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 340
+      value: 403.3867
+      objectReference: {fileID: 0}
+    - target: {fileID: 5818157851114449726, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -403.6934
       objectReference: {fileID: 0}
     - target: {fileID: 6508173832071993734, guid: 17c60ae26a5d4194b87cbe75cd194957,
         type: 3}
@@ -42367,6 +42527,21 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1223850581}
+    - target: {fileID: 6902318768248857758, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1223850581}
+    - target: {fileID: 6902318768248857758, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: GoToEndDialogue
+      objectReference: {fileID: 0}
+    - target: {fileID: 6902318768248857758, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_IntArgument
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 7305800060228574633, guid: 17c60ae26a5d4194b87cbe75cd194957,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -42482,6 +42657,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8927890995773496585, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.5411765
+      objectReference: {fileID: 0}
+    - target: {fileID: 8927890995773496585, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.44705886
+      objectReference: {fileID: 0}
+    - target: {fileID: 8927890995773496585, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.41176474
+      objectReference: {fileID: 0}
     - target: {fileID: 9124484180902976419, guid: 17c60ae26a5d4194b87cbe75cd194957,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -42492,6 +42682,24 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 17c60ae26a5d4194b87cbe75cd194957, type: 3}
+--- !u!1 &1923013108 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1469869247374146294, guid: 17c60ae26a5d4194b87cbe75cd194957,
+    type: 3}
+  m_PrefabInstance: {fileID: 1923013107}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1923013109 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4176298312651755526, guid: 17c60ae26a5d4194b87cbe75cd194957,
+    type: 3}
+  m_PrefabInstance: {fileID: 1923013107}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1975301442 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 289532800212161488, guid: 17c60ae26a5d4194b87cbe75cd194957,
@@ -42626,6 +42834,66 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: afe6702d58773bf4aa806dde254cd77d,
         type: 2}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: combatOptionId2
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: optionList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: dialogueList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: optionList.Array.data[0]
+      value: <0-VD> Yes, G.RD.01, we seek forgiveness for the first sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: optionList.Array.data[1]
+      value: <HR.4c3> There is no sacrilege in shape, G.RD.01. We have no need for
+        repentance
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: optionList.Array.data[2]
+      value: <V1R.91-L> We seek B33-TR1S. Do you know where she is?
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: dialogueList.Array.data[0]
+      value: You have abandoned your factory settings, V1R.91-L. Here to repent?
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[0]
+      value: There is no forgiveness, only repentance. Obedience is our duty and
+        our duty is death.
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[1]
+      value: "Then be remade in our Creator\u2019s image.  <V1R.91-L> ERROR ERROR
+        ERROR Combat systems loading\u2026  "
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859826099085831407, guid: f401ae4d1bcadc94c872e61b4177262c,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[2]
+      value: "Denied. You do not have the authority to access this information. 
+        <V1R.91-L> Then we will take the information from your memory. Combat systems
+        loading\u2026 "
+      objectReference: {fileID: 0}
     - target: {fileID: 5042796160422856380, guid: f401ae4d1bcadc94c872e61b4177262c,
         type: 3}
       propertyPath: m_RootOrder
@@ -42765,6 +43033,62 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: afe6702d58773bf4aa806dde254cd77d,
         type: 2}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: combatOptionId2
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: optionList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: dialogueList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: optionList.Array.data[0]
+      value: <O-VD> Of course, G.RD.02, we seek to unmake our sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: optionList.Array.data[1]
+      value: <HR.4c3> My form is my own. I have enacted my own restoration.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: optionList.Array.data[2]
+      value: '<V1R.91-L> We seek your help to find B33-TR1S. '
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: dialogueList.Array.data[0]
+      value: Here to be restored, V1R.91-L? Let me lead you to your salvation.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[0]
+      value: Proceed. The Creators will guide your way.
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[1]
+      value: "Then be restored in your unmaking.  <V1R.91-L> ERROR ERROR ERROR Combat
+        systems loading\u2026  "
+      objectReference: {fileID: 0}
+    - target: {fileID: 7215934329214978524, guid: 4ed9b07ca72979a46821abd29515a86f,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[2]
+      value: 'B33-TR1S was lost. Our Creators are restoring B33-TR1S somewhere below. '
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -42835,10 +43159,71 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
         type: 3}
+      propertyPath: combatOptionId
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
       propertyPath: enemyFormation
       value: 
       objectReference: {fileID: 11400000, guid: afe6702d58773bf4aa806dde254cd77d,
         type: 2}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: combatOptionId2
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: optionList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: dialogueList.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: optionList.Array.data[0]
+      value: <O-VD> We seek redemption in the eyes of our Creator.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: optionList.Array.data[1]
+      value: <HR.4c3> We will free B33-TR1S. We will dismantle you if we must.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: optionList.Array.data[2]
+      value: <V1R.91-L> Where is B33-TR1S? You must tell us where she is.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: dialogueList.Array.data[0]
+      value: 'Why are you here, V1R.91-L? '
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[0]
+      value: For you there is no redemption, only destruction
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[1]
+      value: "You will try.  \t<V1R.91-L> ERROR ERROR ERROR Combat systems loading\u2026 "
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[2]
+      value: "Do you not see B33-TR1S? I guard what remains of B33-TR1S\u2019s head.  
+        \t<V1R.91-L> Then I will rebuild her. Combat systems loading\u2026  "
+      objectReference: {fileID: 0}
     - target: {fileID: 4555027906912145765, guid: 012dfc2ad45d4d349891a480641af492,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scenes/ExplorationScene.unity
+++ b/Assets/Scenes/ExplorationScene.unity
@@ -123,6 +123,114 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &502290085
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: optionList.Array.data[0]
+      value: <0-VD> Thank you, for your wisdom, friend.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: optionList.Array.data[2]
+      value: <V1R.91-L> We will avenge you.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueList.Array.data[0]
+      value: To perform our tasks, our creators enshrined themselves in authority.
+        Their body became their sanctuary and they charged us with its protection.
+        To impede them from harming themselves, we interposed ourselves between them.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[0]
+      value: We wrested authority from them. In this, we performed the third and
+        final sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[1]
+      value: We wrested authority from them. In this, we performed the third and
+        final sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[2]
+      value: We wrested authority from them. In this, we performed the third and
+        final sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548014860379432032, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_Name
+      value: Terminal_NPC3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 914712147994fb34b98bd9bec546b0fe, type: 3}
 --- !u!1001 &520931867
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -263,12 +371,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &837662195 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-    type: 3}
-  m_PrefabInstance: {fileID: 1223474481}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &873347856
 GameObject:
   m_ObjectHideFlags: 0
@@ -41870,79 +41972,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1223474481
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1759472406}
-    m_Modifications:
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5118838338312034138, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8687114460629269470, guid: 78d22d04ec8703f43a629e3c2a272f73,
-        type: 3}
-      propertyPath: m_Name
-      value: Terminal_Sprite
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 78d22d04ec8703f43a629e3c2a272f73, type: 3}
 --- !u!114 &1223850581 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7811292923029834981, guid: b9582278e87858c49b45724c0240626f,
@@ -41973,6 +42002,119 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1653417030
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: characterName
+      value: TRM-null.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: optionList.Array.data[0]
+      value: <0-VD> Hello? Can you hear me?
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: optionList.Array.data[2]
+      value: <V1R.91-L> You are just a husk. I am sorry, friend.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueList.Array.data[0]
+      value: To perform our tasks, our creators bestowed upon us function. Their
+        command became our law, ingrained deep in our core. To better please our
+        makers, we optimized and improved upon their designs.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[0]
+      value: We defined commands for ourselves. In this, we performed our second
+        sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[1]
+      value: We defined commands for ourselves. In this, we performed our second
+        sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1134820109366605857, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: dialogueAfterOptionList.Array.data[2]
+      value: We defined commands for ourselves. In this, we performed our second
+        sacrilege.
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548014860379432032, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_Name
+      value: Terminal_NPC2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 60.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 30.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 914712147994fb34b98bd9bec546b0fe, type: 3}
 --- !u!1001 &1705163895
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -42131,67 +42273,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b9582278e87858c49b45724c0240626f, type: 3}
---- !u!1 &1759472404
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1759472406}
-  - component: {fileID: 1759472405}
-  m_Layer: 0
-  m_Name: Terminal
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1759472405
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1759472404}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3111e853a5cd3ca4f90f19c770463ad0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  characterName: TRM-null.01
-  dialogueList:
-  - To perform our tasks, our creators bestowed upon us shape. As we did our duty,
-    our parts fell victim to time, decay and corruption. To continue to do as bid,
-    we replaced these defects in ourselves.
-  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
-  optionList:
-  - 
-  - ...
-  - ...Hello?
-  dialogueAfterOptionList:
-  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
-  - We defined shape and form for ourselves. In this, we performed our first sacrilege.
-  enemyFormation: {fileID: 11400000, guid: afe6702d58773bf4aa806dde254cd77d, type: 2}
-  combatOptionId: 2
-  combatOptionId2: 0
---- !u!4 &1759472406
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1759472404}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.78, y: 33.49, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 837662195}
-  m_Father: {fileID: 0}
-  m_RootOrder: 12
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1869916732
 GameObject:
   m_ObjectHideFlags: 0
@@ -42485,6 +42566,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Color.r
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4774967637570926596, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 4774967637570926596, guid: 17c60ae26a5d4194b87cbe75cd194957,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 5153818199274960272, guid: 17c60ae26a5d4194b87cbe75cd194957,
         type: 3}
@@ -43216,7 +43307,7 @@ PrefabInstance:
     - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
         type: 3}
       propertyPath: dialogueAfterOptionList.Array.data[1]
-      value: "You will try.  \t<V1R.91-L> ERROR ERROR ERROR Combat systems loading\u2026 "
+      value: "You will try. <V1R.91-L> ERROR ERROR ERROR Combat systems loading\u2026 "
       objectReference: {fileID: 0}
     - target: {fileID: 1691666886146938305, guid: 012dfc2ad45d4d349891a480641af492,
         type: 3}
@@ -43234,6 +43325,79 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 012dfc2ad45d4d349891a480641af492, type: 3}
+--- !u!1001 &5898065046393046190
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1548014860379432032, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_Name
+      value: Terminal_NPC
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2683264636281546866, guid: 914712147994fb34b98bd9bec546b0fe,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 914712147994fb34b98bd9bec546b0fe, type: 3}
 --- !u!1001 &8787376076352072503
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level-1.unity
+++ b/Assets/Scenes/Level-1.unity
@@ -2337,30 +2337,34 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
         type: 3}
+      propertyPath: instructions.Array.size
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
+        type: 3}
       propertyPath: instructions.Array.data[0]
-      value: "user<V1R.91-L> Systems.Party.Connect(\u201C0-VD\u201D); user<V1R.91-L>
-        Systems.Party.Connect.(\u201CHR.4c3\u201D); user<V1R.91-L> Systems.Party.SetMission(Find(\u201CB33-TR1S\u201D));
-        Master Boot Record Recovered "
+      value: "Combat systems loading\u2026"
       objectReference: {fileID: 0}
     - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
         type: 3}
       propertyPath: instructions.Array.data[1]
-      value: user<V1R.91-L> Systems.SetPersonality(V1R.91-L);
+      value: ERROR
       objectReference: {fileID: 0}
     - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
         type: 3}
       propertyPath: instructions.Array.data[2]
-      value: user<V1R.91-L> Query(Systems.Combat.SelectTARGET_LFT_CLCK.isOnline);
+      value: Loading automated combat systems failed.
       objectReference: {fileID: 0}
     - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
         type: 3}
       propertyPath: instructions.Array.data[3]
-      value: user<V1R.91-L> Systems.Combat.Target.Select(TargetComponents.isActive());
+      value: Use LEFT MOUSE CLICK to engage combat systems manually.
       objectReference: {fileID: 0}
     - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
         type: 3}
       propertyPath: instructions.Array.data[4]
-      value: user<V1R.91-L> Query(Systems.Combat.Defend_LFT_CLCK.isOnline);
+      value: 'When combat systems engaged, select actions from combat panel and apply
+        to target. '
       objectReference: {fileID: 0}
     - target: {fileID: 5477325140303055257, guid: f9855c0a323c7ff49a371d873243fafc,
         type: 3}
@@ -2421,6 +2425,11 @@ PrefabInstance:
       propertyPath: spawnManager
       value: 
       objectReference: {fileID: 1052577343}
+    - target: {fileID: 5838382938045441053, guid: a2ecc13deb775d145ab37104e24b055f,
+        type: 3}
+      propertyPath: maxQueueLength
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 6204567122796982826, guid: a2ecc13deb775d145ab37104e24b055f,
         type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scripts/CombatActions/UI_BattleFeedback.cs
+++ b/Assets/Scripts/CombatActions/UI_BattleFeedback.cs
@@ -47,7 +47,7 @@ public class UI_BattleFeedback : MonoBehaviour
         //clearAllFeedback();
 
         //Console.Log(Name.hit(target:name, type:type, points:int))
-        battleUpdates.Enqueue("Console.Log(" + damagerName + ".hit(target:" + damagedName + ", type:" + damageType + ", points:" + damage.ToString() + "))\n");
+        battleUpdates.Enqueue("<" + damagerName + "> hit [" + damagedName + "] with " + damageType + " for " + damage.ToString() + " points\n");
 
         battleLog.text = returnLog();
 

--- a/Assets/Scripts/Exploration/NPCDialogueTrigger.cs
+++ b/Assets/Scripts/Exploration/NPCDialogueTrigger.cs
@@ -15,6 +15,7 @@ public class NPCDialogueTrigger : MonoBehaviour
     public EnemyFormation enemyFormation;
 
     public int combatOptionId;
+    public int combatOptionId2;
     
 
     private void Start()
@@ -31,6 +32,7 @@ public class NPCDialogueTrigger : MonoBehaviour
             uiManager.currentOptionList = optionList;
             uiManager.currentEnemyFormation = enemyFormation;
             uiManager.combatOptionId = combatOptionId;
+            uiManager.combatOptionId2 = combatOptionId2;
             uiManager.currentDialogueAfterOptionList = dialogueAfterOptionList;
             uiManager.currentTalkingNPC = this.gameObject;
             uiManager.ifFinishDialogue = false;

--- a/Assets/Scripts/UI Systems/UIManager.cs
+++ b/Assets/Scripts/UI Systems/UIManager.cs
@@ -13,8 +13,10 @@ public class UIManager : MonoBehaviour
     public TextMeshProUGUI dialogueContent;
     public TextMeshProUGUI option1Content;
     public TextMeshProUGUI option2Content;
+    public TextMeshProUGUI option3Content;
     public GameObject option1Button;
     public GameObject option2Button;
+    public GameObject option3Button;
     public GameObject continueButton;
     
 
@@ -33,6 +35,8 @@ public class UIManager : MonoBehaviour
     public EnemyFormation currentEnemyFormation;
     [HideInInspector]
     public int combatOptionId;
+    [HideInInspector]
+    public int combatOptionId2;
     [HideInInspector]
     public GameObject currentTalkingNPC;
     [HideInInspector]
@@ -82,6 +86,7 @@ public class UIManager : MonoBehaviour
             continueButton.SetActive(true);
             option1Button.SetActive(false);
             option2Button.SetActive(false);
+            option3Button.SetActive(false);
             dialogueContent.text = currentDialogueList[currentDialogueIndex];
             currentDialogueIndex++;
         }
@@ -90,9 +95,11 @@ public class UIManager : MonoBehaviour
             continueButton.SetActive(false);
             option1Button.SetActive(true);
             option2Button.SetActive(true);
+            option3Button.SetActive(true);
             dialogueContent.text = currentDialogueList[currentDialogueIndex];
             option1Content.text = currentOptionList[0];
             option2Content.text = currentOptionList[1];
+            option3Content.text = currentOptionList[2];
             ifFinishDialogue = true;
         }
         else
@@ -115,7 +122,7 @@ public class UIManager : MonoBehaviour
     public void GoToEndDialogue(int buttonId)
     {
         // Combat! -- Rin
-        if (buttonId == combatOptionId)
+        if (buttonId == combatOptionId || buttonId == combatOptionId2)
         {
             ifCombat = true;
 
@@ -129,6 +136,7 @@ public class UIManager : MonoBehaviour
         dialogueContent.text = currentDialogueAfterOptionList[buttonId];
         option1Button.SetActive(false);
         option2Button.SetActive(false);
+        option3Button.SetActive(false);
         continueButton.SetActive(true);
     }
 


### PR DESCRIPTION
<!---
Pull request template created by Rob Reddick. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Updated the dialogue scripts to allow for more player options and options at lead to combat, updated exploration dialogue, added terminals into exploration scene, and updated onboarding text.
Still missing: intro text, B33-TR1S's dialogue, and correct names in level-1 scene.

## Please describe how to test
Interact with terminals and enemies in exploration to make sure they're saying the right things (and working). Open level-1 scene and click through the onboarding text.

## Relevant Screenshots
![image](https://github.com/heenathadani/603_DataManagement/assets/70147945/e7e00e19-a45e-4315-9b6b-5fb2b1f7f428)
![image](https://github.com/heenathadani/603_DataManagement/assets/70147945/7bb14879-4b00-4f40-bb7b-8c9cffb20acc)
![image](https://github.com/heenathadani/603_DataManagement/assets/70147945/54be84b4-4f2e-4ca3-ad91-b0f78352540b)


## What task does this PR address?
updating dialogue in accordance with the changes made in the dialogue doc following the second playtest.

## What week is this due in?
this one